### PR TITLE
Use new logger funcs and handler API conflict errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `github.com/giantswarm/micrologger` to `v0.4.0` 
+- Use new logger functions `Debugf` and `Errorf`.
+- Handle API conflict errors.
+
 ## [0.1.0] - 2020-12-08
 
 - Generic condition handler for summarizing conditions into a single summary condition.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/giantswarm/conditions v0.2.0
 	github.com/giantswarm/microerror v0.2.1
-	github.com/giantswarm/micrologger v0.3.4
+	github.com/giantswarm/micrologger v0.4.0
 	k8s.io/api v0.18.9
 	k8s.io/apimachinery v0.18.9
 	sigs.k8s.io/cluster-api v0.3.10

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/giantswarm/conditions v0.2.0 h1:sOS319rNgfRl/LuzeEmCcyjYa8V4GCtR4Ntwy
 github.com/giantswarm/conditions v0.2.0/go.mod h1:Bp0zSox1MdFV20MTvjXOr8li+v11OLX/8kponaIGVrw=
 github.com/giantswarm/microerror v0.2.1 h1:4y88WstqZ4OSSq6T/TvTJaefRe/JbrbuwoWQNVxOOyU=
 github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
-github.com/giantswarm/micrologger v0.3.4 h1:NKD6pz1++Hkq/ulOT9iu7hwTnG3ZfjnPUtuK/tbeCc8=
-github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
+github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
+github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
@@ -229,6 +229,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=

--- a/pkg/conditions/upgrading/update.go
+++ b/pkg/conditions/upgrading/update.go
@@ -25,7 +25,7 @@ func MarkUpgradingFalseWithUpgradeCompleted(object conditions.Object) {
 	currentUpgradingCondition := capiconditions.Get(object, conditions.Upgrading)
 	if currentUpgradingCondition != nil {
 		upgradeDuration := time.Since(currentUpgradingCondition.LastTransitionTime.Time)
-		upgradeTimeMessage = fmt.Sprintf("in %s", upgradeDuration)
+		upgradeTimeMessage = fmt.Sprintf(" in %s", upgradeDuration)
 	} else {
 		upgradeTimeMessage = ", but upgrade duration cannot be determined"
 	}


### PR DESCRIPTION
What's in the box:
- Bump `github.com/giantswarm/micrologger` to `v0.4.0` 
- Use new logger functions `Debugf` and `Errorf`.
- Handle API conflict errors.

## Checklist

- [x] Update changelog in CHANGELOG.md.
