### PR TITLE
Add MachinePool ReplicasReady condition handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New handler that is setting `MachinePool` `ReplicasReady` condition. It uses almost same logic to set the condition as the upstream Cluster API controller.
+
+### Changed
+
+- `MachinePool` `Ready` condition is now summarizing `ReplicasReady` and `InfrastructureReady`, so both Kubernetes nodes and Azure infrastructure are taken into account.
+- Added new `ReplicasReady` condition handler to the default `MachinePool` composite handler that is used in `azure-operator`.
+
 ## [0.1.2] - 2020-12-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New handler that is setting `MachinePool` `ReplicasReady` condition. It uses almost same logic to set the condition as the upstream Cluster API controller.
+- New handler that is setting `MachinePool` `ReplicasReady` condition.
 
 ### Changed
 

--- a/pkg/conditions/replicasready/handler.go
+++ b/pkg/conditions/replicasready/handler.go
@@ -1,0 +1,80 @@
+package replicasready
+
+import (
+	"context"
+
+	"github.com/giantswarm/conditions/pkg/conditions"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/conditions-handler/pkg/internal"
+	"github.com/giantswarm/conditions-handler/pkg/key"
+)
+
+type HandlerConfig struct {
+	CtrlClient ctrl.Client
+	Logger     micrologger.Logger
+
+	Name         string
+	UpdateStatus bool
+}
+
+type Handler struct {
+	ctrlClient      ctrl.Client
+	internalHandler *internal.Handler
+	logger          micrologger.Logger
+	name            string
+}
+
+func NewHandler(config HandlerConfig) (*Handler, error) {
+	h := &Handler{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		name:       config.Name,
+	}
+
+	internalHandlerConfig := internal.HandlerConfig{
+		CtrlClient:        config.CtrlClient,
+		Logger:            config.Logger,
+		UpdateStatus:      config.UpdateStatus,
+		ConditionType:     capiexp.ReplicasReadyCondition,
+		EnsureCreatedFunc: h.ensureCreated,
+	}
+
+	internalHandler, err := internal.NewHandler(internalHandlerConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	h.internalHandler = internalHandler
+
+	return h, nil
+}
+
+func (h *Handler) EnsureCreated(ctx context.Context, object interface{}) error {
+	machinePool, err := key.ToMachinePoolPointer(object)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return h.internalHandler.EnsureCreated(ctx, machinePool)
+}
+
+func (h *Handler) EnsureDeleted(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (h *Handler) Name() string {
+	return h.name
+}
+
+func (h *Handler) ensureCreated(ctx context.Context, object conditions.Object) error {
+	machinePool, err := key.ToMachinePoolPointer(object)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	update(machinePool)
+	return nil
+}

--- a/pkg/conditions/replicasready/testdata/machinepool-desired-gt-observed.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-desired-gt-observed.yaml
@@ -1,0 +1,28 @@
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  name: 4nfz5
+  namespace: org-test
+spec:
+  clusterName: z544e
+  failureDomains:
+    - "2"
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap: {}
+      clusterName: z544e
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: 4nfz5
+        namespace: org-giantswarm
+        resourceVersion: "242634105"
+        uid: c89ae1c2-d7c8-4ab7-881d-39cab70eafa1
+status:
+  availableReplicas: 0
+  bootstrapReady: false
+  infrastructureReady: true
+  readyReplicas: 0
+  replicas: 1

--- a/pkg/conditions/replicasready/testdata/machinepool-noderefs-not-set.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-noderefs-not-set.yaml
@@ -1,0 +1,31 @@
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  name: 4nfz5
+  namespace: org-test
+spec:
+  clusterName: z544e
+  failureDomains:
+    - "2"
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap: {}
+      clusterName: z544e
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: 4nfz5
+        namespace: org-giantswarm
+        resourceVersion: "242634105"
+        uid: c89ae1c2-d7c8-4ab7-881d-39cab70eafa1
+status:
+  availableReplicas: 3
+  bootstrapReady: false
+  infrastructureReady: true
+  nodeRefs:
+    - name: nodepool-4nfz5-000006
+      uid: 1f5990d4-1370-4556-9ac4-3f40e9454dd9
+  readyReplicas: 3
+  replicas: 3

--- a/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
@@ -1,0 +1,28 @@
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  name: 4nfz5
+  namespace: org-test
+spec:
+  clusterName: z544e
+  failureDomains:
+    - "2"
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap: {}
+      clusterName: z544e
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: 4nfz5
+        namespace: org-giantswarm
+        resourceVersion: "242634105"
+        uid: c89ae1c2-d7c8-4ab7-881d-39cab70eafa1
+status:
+  availableReplicas: 1
+  bootstrapReady: false
+  infrastructureReady: true
+  readyReplicas: 1
+  replicas: 3

--- a/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
@@ -24,5 +24,10 @@ status:
   availableReplicas: 1
   bootstrapReady: false
   infrastructureReady: true
+  nodeRefs:
+    - name: nodepool-4nfz5-000006
+      uid: 1f5990d4-1370-4556-9ac4-3f40e9454dd9
+    - name: nodepool-4nfz5-000007
+      uid: 6af6b555-e73f-49ac-885a-ae6f9ed4be80
   readyReplicas: 1
   replicas: 3

--- a/pkg/conditions/replicasready/testdata/machinepool-replicasready-true.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-replicasready-true.yaml
@@ -1,0 +1,35 @@
+apiVersion: exp.cluster.x-k8s.io/v1alpha3
+kind: MachinePool
+metadata:
+  name: 4nfz5
+  namespace: org-test
+spec:
+  clusterName: z544e
+  failureDomains:
+    - "2"
+  replicas: 3
+  template:
+    metadata: {}
+    spec:
+      bootstrap: {}
+      clusterName: z544e
+      infrastructureRef:
+        apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AzureMachinePool
+        name: 4nfz5
+        namespace: org-giantswarm
+        resourceVersion: "242634105"
+        uid: c89ae1c2-d7c8-4ab7-881d-39cab70eafa1
+status:
+  availableReplicas: 3
+  bootstrapReady: false
+  infrastructureReady: true
+  nodeRefs:
+    - name: nodepool-4nfz5-000006
+      uid: 1f5990d4-1370-4556-9ac4-3f40e9454dd9
+    - name: nodepool-4nfz5-000007
+      uid: 6af6b555-e73f-49ac-885a-ae6f9ed4be80
+    - name: nodepool-4nfz5-000008
+      uid: d55ddafb-e5be-4ec1-aec4-7abc20c24c02
+  readyReplicas: 3
+  replicas: 3

--- a/pkg/conditions/replicasready/update.go
+++ b/pkg/conditions/replicasready/update.go
@@ -38,7 +38,7 @@ func update(machinePool *capiexp.MachinePool) {
 			machinePool.Status.ReadyReplicas,
 			machinePool.Status.Replicas,
 			len(machinePool.Status.NodeRefs),
-			machinePool.Status.ReadyReplicas)
+			machinePool.Status.Replicas)
 		return
 	}
 

--- a/pkg/conditions/replicasready/update.go
+++ b/pkg/conditions/replicasready/update.go
@@ -20,6 +20,7 @@ func update(machinePool *capiexp.MachinePool) {
 			"Desired number of replicas is %d, but found %d",
 			desiredReplicas,
 			machinePool.Status.Replicas)
+		return
 	}
 
 	// We have found the desired number of replicas.
@@ -33,10 +34,11 @@ func update(machinePool *capiexp.MachinePool) {
 			capiexp.ReplicasReadyCondition,
 			capiexp.WaitingForReplicasReadyReason,
 			capi.ConditionSeverityWarning,
-			"%d/%d replicas are ready, %d node references set",
+			"%d/%d replicas are ready, %d/%d node references set",
 			machinePool.Status.ReadyReplicas,
 			machinePool.Status.Replicas,
-			len(machinePool.Status.NodeRefs))
+			len(machinePool.Status.NodeRefs),
+			machinePool.Status.ReadyReplicas)
 		return
 	}
 

--- a/pkg/conditions/replicasready/update.go
+++ b/pkg/conditions/replicasready/update.go
@@ -1,0 +1,45 @@
+package replicasready
+
+import (
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+)
+
+func update(machinePool *capiexp.MachinePool) {
+	// If value is not specified when MachinePool CR is created, the default
+	// value is ensured in azure-admission-controller.
+	desiredReplicas := *machinePool.Spec.Replicas
+
+	if desiredReplicas > machinePool.Status.Replicas {
+		capiconditions.MarkFalse(
+			machinePool,
+			capiexp.ReplicasReadyCondition,
+			capiexp.WaitingForReplicasReadyReason,
+			capi.ConditionSeverityWarning,
+			"Desired number of replicas is %d, but found %d",
+			desiredReplicas,
+			machinePool.Status.Replicas)
+	}
+
+	// We have found the desired number of replicas.
+
+	// Now check if all found nodes are ready or not, and if all node references
+	// are set.
+	if machinePool.Status.Replicas != machinePool.Status.ReadyReplicas ||
+		len(machinePool.Status.NodeRefs) != int(machinePool.Status.ReadyReplicas) {
+		capiconditions.MarkFalse(
+			machinePool,
+			capiexp.ReplicasReadyCondition,
+			capiexp.WaitingForReplicasReadyReason,
+			capi.ConditionSeverityWarning,
+			"%d/%d replicas are ready, %d node references set",
+			machinePool.Status.ReadyReplicas,
+			machinePool.Status.Replicas,
+			len(machinePool.Status.NodeRefs))
+		return
+	}
+
+	// Desired number of replicas is ready and all node references are set.
+	capiconditions.MarkTrue(machinePool, capiexp.ReplicasReadyCondition)
+}

--- a/pkg/conditions/replicasready/update_test.go
+++ b/pkg/conditions/replicasready/update_test.go
@@ -1,0 +1,109 @@
+package replicasready
+
+import (
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/conditions-handler/pkg/internal"
+)
+
+type updateTestCase struct {
+	name                string
+	machinePoolManifest string
+	expectedCondition   capi.Condition
+}
+
+func TestUpdate(t *testing.T) {
+	testCases := []updateTestCase{
+		{
+			name:                "0: MachinePool with Spec.Replicas greater than Status.Replicas (not all replicas are discovered)",
+			machinePoolManifest: "machinepool-desired-gt-observed.yaml",
+			expectedCondition: capi.Condition{
+				Type:     capiexp.ReplicasReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: capi.ConditionSeverityWarning,
+				Reason:   capiexp.WaitingForReplicasReadyReason,
+				Message:  "Desired number of replicas is 3, but found 1",
+			},
+		},
+		{
+			name:                "1: MachinePool with Status.Replicas greater than Status.ReadyReplicas (not all replicas are ready)",
+			machinePoolManifest: "machinepool-replicas-not-ready.yaml",
+			expectedCondition: capi.Condition{
+				Type:     capiexp.ReplicasReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: capi.ConditionSeverityWarning,
+				Reason:   capiexp.WaitingForReplicasReadyReason,
+				Message:  "1/3 replicas are ready, 0/1 node references set",
+			},
+		},
+		{
+			name:                "2: MachinePool with Status.NodeRef not fully set",
+			machinePoolManifest: "machinepool-noderefs-not-set.yaml",
+			expectedCondition: capi.Condition{
+				Type:     capiexp.ReplicasReadyCondition,
+				Status:   corev1.ConditionFalse,
+				Severity: capi.ConditionSeverityWarning,
+				Reason:   capiexp.WaitingForReplicasReadyReason,
+				Message:  "3/3 replicas are ready, 1/3 node references set",
+			},
+		},
+		{
+			name:                "3: MachinePool with replicas ready",
+			machinePoolManifest: "machinepool-replicasready-true.yaml",
+			expectedCondition: capi.Condition{
+				Type:   capiexp.ReplicasReadyCondition,
+				Status: corev1.ConditionTrue,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// arrange
+			t.Log(tc.name)
+			machinePool := loadMachinePool(t, tc)
+
+			// act
+			update(&machinePool)
+			replicasReady := capiconditions.Get(&machinePool, capiexp.ReplicasReadyCondition)
+
+			// assert
+			if replicasReady == nil {
+				t.Logf(
+					"Condition %s not set, expected %s",
+					capiexp.ReplicasReadyCondition,
+					internal.SprintComparedCondition(&tc.expectedCondition))
+				t.Fail()
+			} else {
+				if !internal.AreEqualWithIgnoringLastTransitionTime(replicasReady, &tc.expectedCondition) {
+					t.Logf(
+						"expected %s, got %s",
+						internal.SprintComparedCondition(&tc.expectedCondition),
+						internal.SprintComparedCondition(replicasReady))
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func loadMachinePool(t *testing.T, tc updateTestCase) capiexp.MachinePool {
+	machinePoolCRPath := filepath.Join("testdata", tc.machinePoolManifest)
+	o, err := internal.LoadCR(machinePoolCRPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machinePool, ok := o.(*capiexp.MachinePool)
+	if !ok {
+		t.Fatalf("couldn't cast object %T to Cluster", o)
+	}
+
+	return *machinePool
+}

--- a/pkg/conditions/replicasready/update_test.go
+++ b/pkg/conditions/replicasready/update_test.go
@@ -39,7 +39,7 @@ func TestUpdate(t *testing.T) {
 				Status:   corev1.ConditionFalse,
 				Severity: capi.ConditionSeverityWarning,
 				Reason:   capiexp.WaitingForReplicasReadyReason,
-				Message:  "1/3 replicas are ready, 0/1 node references set",
+				Message:  "1/3 replicas are ready, 2/3 node references set",
 			},
 		},
 		{

--- a/pkg/internal/test_util.go
+++ b/pkg/internal/test_util.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
@@ -58,6 +59,8 @@ func LoadCR(manifestPath string) (runtime.Object, error) {
 		obj = new(capi.Cluster)
 	case "Machine":
 		obj = new(capi.Machine)
+	case "MachinePool":
+		obj = new(capiexp.MachinePool)
 	case "MockProviderCluster":
 		obj = new(MockProviderCluster)
 	default:

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/conditions/pkg/conditions"
 	"github.com/giantswarm/microerror"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	"github.com/giantswarm/conditions-handler/pkg/errors"
 	"github.com/giantswarm/conditions-handler/pkg/internal"
@@ -23,6 +24,19 @@ func ToClusterPointer(v interface{}) (*capi.Cluster, error) {
 	customObjectPointer, ok := v.(*capi.Cluster)
 	if !ok {
 		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capi.Cluster{}, v)
+	}
+
+	return customObjectPointer, nil
+}
+
+func ToMachinePoolPointer(v interface{}) (*capiexp.MachinePool, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got nil", &capiexp.MachinePool{})
+	}
+
+	customObjectPointer, ok := v.(*capiexp.MachinePool)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capiexp.MachinePool{}, v)
 	}
 
 	return customObjectPointer, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14943

What's in the box?
- New handler that is setting `MachinePool` `ReplicasReady` condition. It uses almost same logic to set the condition as the upstream Cluster API controller.
- `MachinePool` `Ready` condition is now summarizing `ReplicasReady` and `InfrastructureReady`, so both Kubernetes nodes and Azure infrastructure are taken into account.
- Added new `ReplicasReady` condition handler to the default `MachinePool` composite handler that is used in azure-operator.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Add unit tests for new handler.
- [x] Test in `azure-operator`.

## Demo

When node pool creation has just started:
```
$ k get mp 7t6d2 -n org-giantswarm -o json | jq ".status.conditions[] | select (.type==\"ReplicasReady\")"
{
  "lastTransitionTime": "2020-12-23T09:49:39Z",
  "message": "Desired number of replicas is 5, but found 0",
  "reason": "WaitingForReplicasReady",
  "severity": "Warning",
  "status": "False",
  "type": "ReplicasReady"
}
```

During node pool creation:
```
$ k get mp 7t6d2 -n org-giantswarm -o json | jq ".status.conditions[] | select (.type==\"ReplicasReady\")"
{
  "lastTransitionTime": "2020-12-23T10:01:13Z",
  "message": "0/5 replicas are ready, 4/5 node references set",
  "reason": "WaitingForReplicasReady",
  "severity": "Warning",
  "status": "False",
  "type": "ReplicasReady"
}
```

```
$ k get mp 4oap2 -n org-giantswarm -o json | jq ".status.conditions[] | select (.type==\"ReplicasReady\")"
{
  "lastTransitionTime": "2020-12-23T10:59:00Z",
  "message": "6/7 replicas are ready, 7/7 node references set",
  "reason": "WaitingForReplicasReady",
  "severity": "Warning",
  "status": "False",
  "type": "ReplicasReady"
}
```

When node pool is created:

```
$ k get mp gts4f -n org-giantswarm -o json | jq ".status.conditions[] | select (.type==\"ReplicasReady\")"
{
  "lastTransitionTime": "2020-12-23T08:48:25Z",
  "status": "True",
  "type": "ReplicasReady"
}
```