### PR TITLE
Fix replicasready autoscaler issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MachinePool` `ReplicasReady` is not always true in clusters with cluster-autoscaler enabled.
+
 ## [0.2.0] - 2021-01-11
 
 ### Added

--- a/pkg/conditions/replicasready/testdata/machinepool-noderefs-not-set.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-noderefs-not-set.yaml
@@ -8,6 +8,10 @@ spec:
   failureDomains:
     - "2"
   replicas: 3
+  providerIDList:
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/6"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/7"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/8"
   template:
     metadata: {}
     spec:

--- a/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-replicas-not-ready.yaml
@@ -8,6 +8,10 @@ spec:
   failureDomains:
     - "2"
   replicas: 3
+  providerIDList:
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/6"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/7"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/8"
   template:
     metadata: {}
     spec:

--- a/pkg/conditions/replicasready/testdata/machinepool-replicasready-true.yaml
+++ b/pkg/conditions/replicasready/testdata/machinepool-replicasready-true.yaml
@@ -8,6 +8,10 @@ spec:
   failureDomains:
     - "2"
   replicas: 3
+  providerIDList:
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/6"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/7"
+    - "azure:///subscriptions/123456789/resourceGroups/12345/providers/Microsoft.Compute/virtualMachineScaleSets/nodepool-4nfz5/virtualMachines/8"
   template:
     metadata: {}
     spec:

--- a/pkg/conditions/replicasready/update.go
+++ b/pkg/conditions/replicasready/update.go
@@ -7,25 +7,11 @@ import (
 )
 
 func update(machinePool *capiexp.MachinePool) {
-	// If value is not specified when MachinePool CR is created, the default
-	// value is ensured in azure-admission-controller.
-	desiredReplicas := *machinePool.Spec.Replicas
-
-	if desiredReplicas > machinePool.Status.Replicas {
-		capiconditions.MarkFalse(
-			machinePool,
-			capiexp.ReplicasReadyCondition,
-			capiexp.WaitingForReplicasReadyReason,
-			capi.ConditionSeverityWarning,
-			"Desired number of replicas is %d, but found %d",
-			desiredReplicas,
-			machinePool.Status.Replicas)
+	if len(machinePool.Spec.ProviderIDList) == 0 {
 		return
 	}
 
-	// We have found the desired number of replicas.
-
-	// Now check if all found nodes are ready or not, and if all node references
+	// Check if all found nodes are ready or not, and if all node references
 	// are set.
 	if machinePool.Status.Replicas != machinePool.Status.ReadyReplicas ||
 		len(machinePool.Status.NodeRefs) != int(machinePool.Status.ReadyReplicas) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15297

What's in the box:
- Don't check MachinePool.Spec.Replicas for ReplicasReady
    
Cluster Autoscaler is changing the number of nodes dynamically, depending on the cluster workload demands. This means that desired number of replicas that is set in MachinePool.Spec.Replicas does not always have a correct value.
    
For now we can ignore MachinePool.Spec.Replicas when setting ReplicasReady. We can have a better solution in the future once we have adopted Cluster API even more and when we can start using CAPI provider for Cluster Autoscaler.

## Checklist

- [x] Update changelog in CHANGELOG.md.
